### PR TITLE
Took a two-line script and made it a hundred line script

### DIFF
--- a/generate.rb
+++ b/generate.rb
@@ -1,12 +1,65 @@
 #!/usr/bin/env ruby
+#
+require 'optparse'
+require 'pp'
 
-# Generate ten strong passwords that are easy to remember.
+# Generate strong passwords that are easy to remember.
 # https://xkcd.com/936/
-
 words = DATA.readlines.map(&:strip)
-10.times do
-  puts 4.times.collect { words.sample }.join(" ")
+
+options = {}
+optparse = OptionParser.new do |opts|
+  opts.banner = 'Usage: generate.rb [options]'
+
+  options[:num_words] = 4
+  opts.on('-w', '--words N', Integer, 'Number of words') do |num_words|
+    options[:num_words] = num_words
+  end
+
+  options[:min_length] = 0
+  opts.on('-l', '--minlength N', Integer,
+          'Minimum total length of password') do |min_length|
+    options[:min_length] = min_length
+  end
+
+  options[:max_length] = 100
+  opts.on('-L', '--maxlength N', Integer,
+          'Maximum total length of password') do |max_length|
+    options[:max_length] = max_length
+  end
+
+  options[:delimiter] = ' '
+  opts.on('-d', '--delimiter [string]',
+          'Delimiter between words') do |delimiter|
+    options[:delimiter] = delimiter
+  end
+
+  options[:num_passwords] = 10
+  opts.on('-n', '--numpasswords N', Integer,
+          'Number of passwords to generate') do |num_passwords|
+    options[:num_passwords] = num_passwords
+  end
+
+  opts.on('-h', '--help', 'Display this screen') do
+    puts opts
+    exit
+  end
 end
+optparse.parse!
+
+passwords = (1..100_000)
+  .lazy
+  .map { options[:num_words].times.collect { words.sample }.join(options[:delimiter]) }
+  .filter { |pw| options[:min_length] < pw.length && pw.length <= options[:max_length] }
+  .first(options[:num_passwords])
+
+if passwords.empty?
+  warn 'Could not find any passwords within your criteria:'
+  PP.pp(options, $stderr)
+  abort
+end
+
+passwords.each { |pw| puts pw }
 
 __END__
 aaron


### PR DESCRIPTION
But now everything can be configured with command-line args!

What happened was, I am setting up a new internet-of-things device (oh no) which requires a wifi connection for initial setup (oh no) but only supports wifi passwords <= 20 characters (oh no).

I decided what I would do was create a guest network on my router, with a password of 20 characters. But how to generate a memorable, easy-to-type-on-touchscreen password, of exactly 20 characters?!?! Better spend 45 minutes hacking the five year old West Arete password generator, instead of like, opening a dictionary. Booyah.

```sh
$ ruby generate.rb -h
Usage: generate.rb [options]
    -w, --words N                    Number of words
    -l, --minlength N                Minimum total length of password
    -L, --maxlength N                Maximum total length of password
    -d, --delimiter [string]         Delimiter between words
    -n, --numpasswords N             Number of passwords to generate
    -h, --help                       Display this screen

$ ruby generate.rb -l 19 -L 20 -d . -w 3
weddings.rods.ruling
yukon.gaining.starts
flush.hereby.digital
city.beacon.material
planners.arms.brakes
apart.wiley.memorial
julia.native.injured
tongue.somalia.pride
truth.tucker.officer
swiss.peoples.nextel
```

The options are defaulted so that if you give it no command line options, it will behave exactly the way it did before. But now you've got powah!

![Unless You Got Power!!!](https://lh3.googleusercontent.com/proxy/6jOmbR3EsuMnwlgjfeGxM-SAZqj24lCJOsB0bQl-dWT36FaVI7Ntw99melwnSrbFLcIabKW5rfKHE1FwUh149mtLEf0wfuAbhT7ZDmKvQQwycTq5PC2AXE1_1aR2rFC5BufdHp9kQhu2k7iXu9DXKY6enCWUrA0_YwU)
