### PR TITLE
Exclude some letters from the passwords

### DIFF
--- a/generate.rb
+++ b/generate.rb
@@ -40,12 +40,25 @@ optparse = OptionParser.new do |opts|
     options[:num_passwords] = num_passwords
   end
 
+  options[:exclude] = ''
+  opts.on('-x', '--exclude [string]',
+          'Exclude these letters from the passwords') do |exclude|
+    options[:exclude] = exclude
+  end
+
+  opts.on('--dh',
+          'Use only the common letters between Colemak and Colemak-DH') do |dh_mode|
+    options[:exclude] << 'bgvdmh'
+  end
+
   opts.on('-h', '--help', 'Display this screen') do
     puts opts
     exit
   end
 end
 optparse.parse!
+
+words = words.reject { |w| w.match?(/[#{options[:exclude]}]/i) } if 0 < options[:exclude].length
 
 passwords = (1..100_000)
   .lazy


### PR DESCRIPTION
Adds two options, one to exclude an arbitrary list of letters from the passwords. 

The other option does the same thing, but specifically excludes the different letters between [Colemak](https://user-images.githubusercontent.com/14730/134217044-e0589106-c42d-40e9-ab33-68d6b49b96f1.png)
 and [Colemak-DH](https://user-images.githubusercontent.com/14730/134217080-6a92f1e0-e655-4ff7-99ec-45c3a7df89b2.png). Supposing you decided to learn a new keyboard layout, and you chose the newer improved version of Colemak, Colemak-DH, which changes a few keys around. MacOS ships with Colemak but not DH, which must be installed manually. Moooooost of the time your manually installed version of DH will show up on the Mac boot screen's password prompt, but it's buggy and doesn't always appear _every time._ Therefore it would be smart to pick a password that contains no letters that are different between Colemak and DH, that way in case DH does not appear in the login prompt, you can still touch type your password with the system's Colemak layout which will always be there.

